### PR TITLE
Change Paths for honeybee according to new namespace to honeybee_plus

### DIFF
--- a/plugin/grasshopper/src/HoneybeePlus Installer.py
+++ b/plugin/grasshopper/src/HoneybeePlus Installer.py
@@ -22,7 +22,7 @@ C:\Users\%USERNAME%\AppData\Roaming\McNeel\Rhinoceros\6.0\scripts
 
 ghenv.Component.Name = "HoneybeePlus Installer"
 ghenv.Component.NickName = "HBInstaller"
-ghenv.Component.Message = 'VER 0.0.06\nJUL_07_2020'
+ghenv.Component.Message = 'VER 0.0.06\nJUL_13_2020'
 ghenv.Component.Category = "HoneybeePlus"
 ghenv.Component.SubCategory = "05 :: Developers"
 ghenv.Component.AdditionalHelpFromDocStrings = "1"

--- a/plugin/grasshopper/src/HoneybeePlus Installer.py
+++ b/plugin/grasshopper/src/HoneybeePlus Installer.py
@@ -129,6 +129,8 @@ def updateHoneybee():
                 if f != 'honeybee' else os.path.join(targetDirectory, 'honeybee_plus')
         if not os.path.isdir(libFolder):
             os.mkdir(libFolder)
+        if sourceFolder.endswith('honeybee'):
+            sourceFolder=sourceFolder+'_plus'  #addition to find correct path
         print 'Copying {} source code to {}'.format(f, libFolder)
         copy_tree_full(sourceFolder, libFolder)
     


### PR DESCRIPTION
Files during installation couldn't be found because of new path structure in github 'honeybee_plus'.